### PR TITLE
Add `unique_id` field to mqtt

### DIFF
--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -169,7 +169,8 @@ class MQTT {
             state_topic: this.getStateTopic(diag),
             value_template: `{{ value_json.${MQTT.convertName(diagEl.name)} }}`,
             json_attributes_topic: _.isUndefined(attr) ? undefined : this.getStateTopic(diag),
-            json_attributes_template: attr
+            json_attributes_template: attr,
+            unique_id: `${this.vehicle.vin}-${device_class}-${name}`
         };
     }
 

--- a/src/mqtt.js
+++ b/src/mqtt.js
@@ -154,6 +154,9 @@ class MQTT {
     mapBaseConfigPayload(diag, diagEl, device_class, name, attr) {
         name = name || MQTT.convertFriendlyName(diagEl.name);
         name = this.addNamePrefix(name);
+        // Generate the unique id from the vin and name
+        let unique_id = `${this.vehicle.vin}-${diagEl.name}`
+        unique_id = unique_id.replace(/\s+/g, '-').toLowerCase();
         return {
             device_class,
             name,
@@ -170,7 +173,7 @@ class MQTT {
             value_template: `{{ value_json.${MQTT.convertName(diagEl.name)} }}`,
             json_attributes_topic: _.isUndefined(attr) ? undefined : this.getStateTopic(diag),
             json_attributes_template: attr,
-            unique_id: `${this.vehicle.vin}-${device_class}-${name}`
+            unique_id: unique_id
         };
     }
 

--- a/test/mqtt.spec.js
+++ b/test/mqtt.spec.js
@@ -92,6 +92,7 @@ describe('MQTT', () => {
                     payload_available: 'true',
                     payload_not_available: 'false',
                     state_topic: 'homeassistant/sensor/XXX/ambient_air_temperature/state',
+                    unique_id: 'xxx-ambient-air-temperature',
                     json_attributes_topic: undefined,
                     unit_of_measurement: '°C',
                     value_template: '{{ value_json.ambient_air_temperature }}'
@@ -112,6 +113,7 @@ describe('MQTT', () => {
                     payload_available: 'true',
                     payload_not_available: 'false',
                     state_topic: 'homeassistant/sensor/XXX/ambient_air_temperature/state',
+                    unique_id: 'xxx-ambient-air-temperature-f',
                     json_attributes_topic: undefined,
                     unit_of_measurement: '°F',
                     value_template: '{{ value_json.ambient_air_temperature_f }}'
@@ -146,6 +148,7 @@ describe('MQTT', () => {
                     payload_off: false,
                     payload_on: true,
                     state_topic: 'homeassistant/binary_sensor/XXX/ev_charge_state/state',
+                    unique_id: 'xxx-priority-charge-indicator',
                     json_attributes_topic: undefined,
                     value_template: '{{ value_json.priority_charge_indicator }}'
                 });
@@ -178,6 +181,7 @@ describe('MQTT', () => {
                     payload_available: 'true',
                     payload_not_available: 'false',
                     state_topic: 'homeassistant/sensor/XXX/tire_pressure/state',
+                    unique_id: 'xxx-tire-pressure-lf',
                     json_attributes_topic: 'homeassistant/sensor/XXX/tire_pressure/state',
                     unit_of_measurement: 'kPa',
                     value_template: '{{ value_json.tire_pressure_lf }}'


### PR DESCRIPTION
This pr adds the `unique_id` field to the json that gets stored in mqtt. This allows users to be able to edit the name and location as well as see all the sensors listed under the device.

<img width="2168" alt="image" src="https://user-images.githubusercontent.com/727458/169532423-e04dec7d-064d-448d-9cdd-0f142e000679.png">
