### PR TITLE
Upgrade docker image to node:alpine-18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:12
+FROM node:18-alpine
 
 RUN mkdir /app
 WORKDIR /app
 
 COPY ["package.json", "/app/"]
 COPY ["package-lock.json", "/app/"]
-RUN npm install --no-fund
+RUN npm ci --omit=dev --no-fund
 
 COPY ["src", "/app/src"]
 


### PR DESCRIPTION
As titled;
- Reduce docker image size from 1gb+ to ~185mb via alpine base image 
- Upgrade node from v12 (no longer supported) to v18.
- Use `npm ci` to avoid unintended upgrades when building the container.
- Add `--omit=dev` flag because we don't need dev dependencies in "production".