### PR TITLE
Added a definition for the API URL for users outside the US

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:12
+FROM node:18-alpine
 
 RUN mkdir /app
 WORKDIR /app
 
 COPY ["package.json", "/app/"]
 COPY ["package-lock.json", "/app/"]
-RUN npm install --no-fund
+RUN npm ci --omit=dev --no-fund && npm cache clean --force
 
 COPY ["src", "/app/src"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,7 @@ WORKDIR /app
 
 COPY ["package.json", "/app/"]
 COPY ["package-lock.json", "/app/"]
-<<<<<<< HEAD
-RUN npm ci --omit=dev --no-fund && npm cache clean --force
-=======
 RUN npm ci --omit=dev --no-fund
->>>>>>> a539375ae55cd013b9fb169e3180b5f96cd6b5d0
 
 COPY ["src", "/app/src"]
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ ONSTAR_PASSWORD=
 ONSTAR_PIN=
 MQTT_USERNAME=
 MQTT_PASSWORD=
+
+#For Canadian users, specify the canadian end-point as well:
+ONSTAR_URL=https://api.gm.ca
 ```
 ### Node.js
 It's a typical node.js application, define the same environment values as described in the docker sections and run with:

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+sudo docker build -t onstar2mqtt .
+sudo docker-compose rm -sf
+sudo docker-compose up -d
+sudo docker system prune -f

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ const onstarConfig = {
     username: process.env.ONSTAR_USERNAME,
     password: process.env.ONSTAR_PASSWORD,
     onStarPin: process.env.ONSTAR_PIN,
+    serviceUrl: process.env.ONSTAR_URL || "https://api.gm.com",
     checkRequestStatus: process.env.ONSTAR_SYNC === "true" || true,
     refreshInterval: parseInt(process.env.ONSTAR_REFRESH) || (30 * 60 * 1000), // 30 min
     allowCommands: _.toLower(_.get(process, 'env.ONSTAR_ALLOW_COMMANDS', 'true')) === 'true'


### PR DESCRIPTION
This resolves issue #161 by added a variable to specify the endpoint. In Canada, we must use api.gm.ca instead of .com