### PR TITLE
Add an example automation to automatically update location

### DIFF
--- a/HA-MQTT.md
+++ b/HA-MQTT.md
@@ -60,6 +60,20 @@ sequence:
 mode: single
 icon: 'mdi:map-marker'
 ```
+### Automation:
+Create an automation to update the location whenever the odometer changes, instead of on a time interval.
+```alias: Update EV Location
+description: ""
+trigger:
+  - platform: state
+    entity_id:
+      - sensor.odometer_mi
+condition: []
+action:
+  - service: script.locate_bolt_ev
+    data: {}
+mode: single
+```
 
 #### Commands:
 [OnStarJS Command Docs](https://github.com/samrum/OnStarJS#commands)


### PR DESCRIPTION
The examples provided have a good start, but I suggest adding an example automation to automatically update the vehicle's location so users have everything needed to have location updates automatically. I have done this by triggering the automation when the odometer changes, that way we aren't wasting onstar calls when the vehicle is sitting still.